### PR TITLE
make draft objects publishable

### DIFF
--- a/on_demand/api/public-api.js
+++ b/on_demand/api/public-api.js
@@ -153,4 +153,30 @@ router.post('/discord-auth-attempt', (req, res, next) => {
   })
 })
 
+// TODO: uncovered
+// This will return only public drafts.
+router.get('/draft/_id/:_id', (req, res, next) => {
+  const { MONGO_URL, DATABASE } = req.webtaskContext.secrets;
+  MongoClient.connect(MONGO_URL, (err, client) => {
+    const { _id } = req.params;
+    if (assertStringOr400(_id, res)) return;
+    if (err) return next(err);
+    client.db(DATABASE).collection(draftCollection).findOne({ _id: new ObjectID(_id), public: true }, (err, result) => {
+      client.close();
+      if (err) return next(err);
+      cleanDraftRecord(result)
+      console.log(result)
+      if (result !== null)
+      {
+        let safe_result = {}
+        safe_result.picks = result.picks
+        safe_result.date = result.date
+        safe_result._id = result.id
+        res.status(200).send(safe_result)
+      }
+      else res.status(404).send(result)
+    });
+  });
+});
+
 module.exports = router

--- a/on_demand/api/user-api.js
+++ b/on_demand/api/user-api.js
@@ -429,7 +429,7 @@ router.get('/draft/_id/:_id', (req, res, next) => {
       if (err) return next(err);
       cleanDraftRecord(result)
       console.log(result)
-      if (!request.public && !req.authorizedTrackers.includes(result.trackerIDHash)) res.status(401).send({"error": "not authorized"})
+      if (!req.authorizedTrackers.includes(result.trackerIDHash)) res.status(401).send({"error": "not authorized"})
       if (result !== null) res.status(200).send(result)
       else res.status(404).send(result)
     });
@@ -452,7 +452,7 @@ router.post('/draft/_id/:id/publish', (req, res, next) => {
         result.public = true;
         collection(draftCollection).save(result);
         res.status(200).send({published: _id});
-      } 
+      }
       else res.status(404).send(result)
     });
   });
@@ -475,7 +475,7 @@ router.post('/draft/_id/:id/unpublish', (req, res, next) => {
         result.public = false;
         collection(draftCollection).save(result);
         res.status(200).send({published: _id});
-      } 
+      }
       else res.status(404).send(result)
     });
   });


### PR DESCRIPTION
This adds a /publish and /unpublish endpoint to the draft object, as well as adding a condition to the retrieve endpoint where published drafts can be retrieved no matter who the requesting user is (drafts are private by default)

I haven't run this myself so i'm hoping this is small enough not to hurt anything!